### PR TITLE
Update FoodDataMixin.java

### DIFF
--- a/src/main/java/ru/markthelark/spiceofoverhaul/mixin/FoodDataMixin.java
+++ b/src/main/java/ru/markthelark/spiceofoverhaul/mixin/FoodDataMixin.java
@@ -53,7 +53,8 @@ public abstract class FoodDataMixin implements FoodHashAccessor {
                     this.foodHash.put(itemString, 0);
                 }
                 int eaten = this.foodHash.get(itemString);
-                this.eat((int) (properties.nutrition() * Math.pow(0.7, eaten)), properties.saturation());
+                this.saturationLevel = Math.min(this.saturationLevel + properties.saturation(), 20.0F);
+                this.eat((int) (properties.nutrition() * Math.pow(0.7, eaten)), 0.0F);
                 if (this.foodQueue.size() >= this.historyLength) {
                     String elem = this.foodQueue.pollFirst();
                     this.foodHash.put(elem, this.foodHash.get(elem) - 1);
@@ -76,7 +77,8 @@ public abstract class FoodDataMixin implements FoodHashAccessor {
                 }
         }
         else {
-                this.eat(properties.nutrition(), properties.saturation());
+                this.saturationLevel = Math.min(this.saturationLevel + properties.saturation(), 20.0F);
+                this.eat(properties.nutrition(), 0.0F);
         }
     }
     @Inject(at = @At(value = "TAIL"), method = "addAdditionalSaveData(Lnet/minecraft/nbt/CompoundTag;)V")


### PR DESCRIPTION
Prevents modifying Saturation, stops default minecraft behaviour clamping saturation to the food value.